### PR TITLE
Update for new sacct format

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Training materials for a hands-on workshop on introduction to HPC using NeSI, in
 
 #### Contributors:
 
-Murray Cadzow, Matthew Healey, Gene Soudlenkov, Sung Bae, Benjamin Roberts,  Bart Verleye, Jordi Blasco, Martin Feller, Peter Maxwell, Sina Masoud-Ansari, Danny Baillie, Tom Kelly, Alexander Pletzer and Aleksandra Pawlik
+Murray Cadzow, Matthew Healey, Gene Soudlenkov, Sung Bae, Benjamin Roberts,  Bart Verleye, Jordi Blasco, Martin Feller, Peter Maxwell, Sina Masoud-Ansari, Danny Baillie, Tom Kelly, Alexander Pletzer, Chris Scott and Aleksandra Pawlik
 (if you are contributing to the materials, please add your name to the list)
 
 

--- a/lessons/02-hpc-environment.md
+++ b/lessons/02-hpc-environment.md
@@ -112,7 +112,7 @@ Syntax :```module [options] sub-command [args ...]```
 * avail | av: List available modules
 * avail | av string: List available modules that contain "string".
 * spider: List all possible modules
-* spider module" List all possible version of that module file
+* spider module: List all possible version of that module file
 * spider string: List all module that contain the "string".
 
 #### Short-cuts

--- a/lessons/03-slurm.md
+++ b/lessons/03-slurm.md
@@ -121,7 +121,7 @@ And the output will look more or less like this:
 61568970 merit_sho     wrap  apaw363 PD       0:00      1 (Resources)
 ```
 
-Another useful SLURM command is `saccat` which retrieves information about submitted jobs with regards to the accounts. For example:
+Another useful SLURM command is `sacct` which retrieves information about completed jobs. For example:
 
 ```
 sacct -j 61568970
@@ -130,11 +130,13 @@ sacct -j 61568970
 Will show us something like:
 
 ```
-       JobID    JobName  Partition    Account  AllocCPUS      State ExitCode 
------------- ---------- ---------- ---------- ---------- ---------- -------- 
-61568970           wrap merit_sho+  nesi00357          1  COMPLETED      0:0 
-61568970.ba+      batch             nesi00357          1  COMPLETED      0:0 
+        JobName        JobID      User               Start    Elapsed     AveCPU     MinCPU   TotalCPU  AllocCPUS      State     ReqMem     MaxRSS                       NodeList
+--------------- ------------ --------- ------------------- ---------- ---------- ---------- ---------- ---------- ---------- ---------- ---------- ------------------------------
+           wrap     61568970   apaw363 2017-09-22T08:05:28   00:00:00                        00:00.071          1  COMPLETED        1Gc                       compute-physics-001
+          batch 61568970.ba+           2017-09-22T08:05:28   00:00:00   00:00:00   00:00:00  00:00.071          1  COMPLETED        1Gc      1760K            compute-physics-001
 ```
+
+The "MaxRSS" column reports the memory used during the job and is useful when trying to determine a sensible amount of memory to request in the submission script.
 
 ### Job outputs
 


### PR DESCRIPTION
New `sacct` format on Pan is useful as it lets users check memory usage of jobs - assume we will keep this format on the new machines.