### PR TITLE
Changes discussed in user test

### DIFF
--- a/_lessons/kupe/002-accessing_resources.md
+++ b/_lessons/kupe/002-accessing_resources.md
@@ -42,7 +42,7 @@ If you are logging in for the first time to Kupe, you will need to set up your a
 4. After receiving confirmation from our support team to continue,log in to the [My NeSI Portal](https://my.nesi.org.nz) again. Once you have logged in, you should see a screen similar to the one below. Click on the 'Reset Password' button to proceed.
 wait for us to confirm your account and add you to an appropriate project group. This is currently a manual step that we aim to complete for every user within two business days of receiving the request.
 
-If you don't see the 'Reset Password' button and instead see error messages, it means your information on our database does not match your Tuakiri identity, your user account has not yet been created, or you are not a member of an active project. In this case, please email [support@nesi.org.nz](mailto:support@nesi.org.nz?subject=Please%20confirm%20my%20My%20NeSI%20account%20and%20add%20me%20to%20a%20project%20team) and 
+   If you don't see the 'Reset Password' button and instead see error messages, it means your information on our database does not match your Tuakiri identity, your user account has not yet been created, or you are not a member of an active project. In this case, please email [support@nesi.org.nz](mailto:support@nesi.org.nz?subject=Please%20confirm%20my%20My%20NeSI%20account%20and%20add%20me%20to%20a%20project%20team) and 
 
    **NOTE:** You must wait at least an hour between password reset requests. If you request a password reset before an hour has gone by since your last valid password reset request, our system will ignore the later request.
    

--- a/_lessons/kupe/002-accessing_resources.md
+++ b/_lessons/kupe/002-accessing_resources.md
@@ -36,12 +36,11 @@ If you are logging in for the first time to Kupe, you will need to set up your a
    ![logging-in](../../assets/img/tuakiri_credentials.png)
    ![logging-in](../../assets/img/niwa_turakiri.png)
 
-1. You will be asked to fill out some fields, such as your role at your institution and a contact telephone number.
-   ![logging-in](../../assets/img/request_an_account.png)
 1. If this is the first time you have logged in to the [My NeSI Portal](https://my.nesi.org.nz):
 
-   * If you do not have an existing account with NeSI on Pan, please click the button to request an account on Kupe. After submitting your request, you must wait for our support team to contact you via email before continuing.
-   * If you have a Pan account, after logging in you will need to email [support@nesi.org.nz](mailto:support@nesi.org.nz?subject=Please%20confirm%20my%20My%20NeSI%20account%20and%20add%20me%20to%20a%20project%20team) and inform us that you would like access to Kupe so that we can add you to a group with Kupe access rights.
+   * If you do not have an existing account with NeSI on Pan you will be asked to fill out some fields, such as your role at your institution and a contact telephone number, an example of which can be seen below.
+   * If you have a Pan account, after logging in you will need to email [support@nesi.org.nz](mailto:support@nesi.org.nz?subject=Please%20confirm%20my%20My%20NeSI%20account%20and%20add%20me%20to%20a%20project%20team) and and inform us that you would like access to Kupe so that we can add you to a group with Kupe access rights.
+   ![logging-in](../../assets/img/request_an_account.png)
    
 1. Please wait for us to confirm your account and group membership. This is currently a manual step that we aim to complete for every user within two business days of receiving the request.
 

--- a/_lessons/kupe/002-accessing_resources.md
+++ b/_lessons/kupe/002-accessing_resources.md
@@ -20,7 +20,7 @@ You will need a terminal program to log in to Kupe:
 - Windows: [MobaXterm](https://mobaxterm.mobatek.net/), Windows 10 bash, or [PuTTY](https://www.putty.org/)
 - MacOS X: Terminal app, iTerm2
 - Linux: Terminal app, xterm
-- A smartphone with the Google Authenticator app installed
+- A smartphone with the Google Authenticator app or another compatable authenticator app installed
 
 ---
 
@@ -31,19 +31,19 @@ If you are logging in for the first time to Kupe, you will need to set up your a
 1. Access the [My NeSI Portal](https://my.nesi.org.nz) via your browser.
    ![logging-in](../../assets/img/portal_login.png)
 
-2. Log in using your institutional credentials via Tuakiri. If your institution is not a member of the Tuakiri federation, you will have to request a Tuakiri Virtual Home account by emailing [support@nesi.org.nz](mailto:support@nesi.org.nz?subject=Tuakiri%20virtual%20home%20account%20request). Once we have approved and created your Tuakiri Virtual Home account, please select the Tuakiri Virtual Home as your Home Organisation. See the example below, which shows the login process using a NIWA staff username and password. When logging in, please select your own home organisation.
+2. Log in using your institutional credentials via Tuakiri. If your institution is not a member of the Tuakiri federation, you will have to follow the 'Apply for a NeSI Account' link below th 'Log in' button to request a Tuakiri Virtual Home account. Once we have approved and created your Tuakiri Virtual Home account, please select the Tuakiri Virtual Home as your Home Organisation. See the example below, which shows the login process using a NIWA staff username and password. Otherwise, when logging in, please select your own home organisation.
    ![logging-in](../../assets/img/tuakiri_credentials.png)
    ![logging-in](../../assets/img/niwa_turakiri.png)
 
-3. If this is the first time you have logged in to the [My NeSI Portal](https://my.nesi.org.nz) you will be prompted to request an account, after filling out some required fields. After submitting your request you must wait for our support team to contact you via email before continuing. 
+3. If this is the first time you have logged in to the [My NeSI Portal](https://my.nesi.org.nz) and you do not have an existing account with NeSI on Pan you will be prompted to request an account, after filling out some required fields. After submitting your request you must wait for our support team to contact you via email before continuing. If you have a Pan account, after logging in you will need to email [support@nesi.org.nz](mailto:support@nesi.org.nz?subject=Please%20confirm%20my%20My%20NeSI%20account%20and%20add%20me%20to%20a%20project%20team) and inform us that you are attempting to gain access to Kupe so that we can manually ensure that you have proper group membership needed to gain access.
 
    ![logging-in](../../assets/img/request_an_account.png)
    
 4. After receiving confirmation from our support team to continue,log in to the [My NeSI Portal](https://my.nesi.org.nz) again. Once you have logged in, you should see a screen similar to the one below. Click on the 'Reset Password' button to proceed.If you don't see the 'Reset Password' button and instead see error messages, it means your information on our database does not match your Tuakiri identity, your user account has not yet been created, or you are not a member of an active project. In this case, please email [support@nesi.org.nz](mailto:support@nesi.org.nz?subject=Please%20confirm%20my%20My%20NeSI%20account%20and%20add%20me%20to%20a%20project%20team) and wait for us to confirm your account and add you to an appropriate project group. This is currently a manual step that we aim to complete for every user within two business days of receiving the request.
 
-   ![logging-in](../../assets/img/login_success.png)
-
    **NOTE:** You must wait at least an hour between password reset requests. If you request a password reset before an hour has gone by since your last valid password reset request, our system will ignore the later request.
+   
+   ![logging-in](../../assets/img/login_success.png)
    
 5. You will be sent an e-mail with a temporary URL. If you do not receive this email within a few minutes, check your spam filter.
 
@@ -54,7 +54,19 @@ If you are logging in for the first time to Kupe, you will need to set up your a
 
    ![logging-in](../../assets/img/temp_password.png)
 
-7. Once you have logged in with your temporary password, you will be asked to choose a new permanent password. This is a **six-step** process, detailed below. Once you have changed your password, your connection will eventually be terminated with `Permission denied (keyboard-interactive).` or `Access denied (keyboard-interactive).`. This is normal until you set up your second factor.
+### NeSI password policy
+
+The NeSI password policy is as follows:
+  * Your password must be at least 12 characters long
+  * Your password must contain one or more characters from at least two of the following classes:
+    * upper case letters
+    * lower case letters
+    * numbers
+    * allowed special characters
+   
+---
+
+7. Resetting your password is a **six-step** process, detailed below. Once you have changed your password, your connection will eventually be terminated with `Permission denied (keyboard-interactive).` or `Access denied (keyboard-interactive).`. This is normal until you set up your second factor. Please ensure you read all six steps before proceeding as the output messages are easilly misleading.
 
       You can choose your permanent password by following this **six-step** process:
    1. For those using a Mac or Linux computer, connect to the lander node using the command:`ssh -Y <myusername>@lander.nesi.org.nz`, where `<myusername>` should be replaced with your Kupe login name, which you can find by logging in to [the My NeSI portal](https://my.nesi.org.nz) (not to be confused with your institutional login name). For those using a Windows computer, start a new session on MobaXterm and set the Remote Host to `lander.nesi.org.nz` and your username as your Kupe username. **Note:** When you first attempt to SSH into the lander node you may be met with a message warning you that the authenticity of the host cannot be established and asking if you wish to continue. You must type `yes` and press the `Enter` key. Typing `y` as a shorthand for "yes" is not sufficient.
@@ -91,18 +103,6 @@ If you are logging in for the first time to Kupe, you will need to set up your a
    If you have to enter more than four passwords, something has probably gone wrong. You may have entered the wrong temporary password at one of the first two prompts, your new password may not satisfy our password criteria, or you may have mistyped your new password when confirming it. Alternatively, you may have accidentally pressed `Enter` or `Ctrl-C` at the wrong time. If any of these situations has happened, you should exit the session and log in again.
 
 8. You are now ready to move on to setting up two-factor authentication.
-
-### NeSI password policy
-
-The NeSI password policy is as follows:
-  * Your password must be at least 12 characters long
-  * Your password must contain one or more characters from at least two of the following classes:
-    * upper case letters
-    * lower case letters
-    * numbers
-    * allowed special characters
-   
----
 
 ## Setting up two-factor authentication
 

--- a/_lessons/kupe/002-accessing_resources.md
+++ b/_lessons/kupe/002-accessing_resources.md
@@ -15,12 +15,13 @@ You will learn how to:
 
 ## Requirements
 
-You will need a terminal program to log in to Kupe:
+You will need:
 
-- Windows: [MobaXterm](https://mobaxterm.mobatek.net/), Windows 10 bash, or [PuTTY](https://www.putty.org/)
-- MacOS X: Terminal app, iTerm2
-- Linux: Terminal app, xterm
-- A smartphone with the Google Authenticator app or another compatible authenticator app installed
+ * A terminal program to log in to Kupe:
+   * Windows: [MobaXterm](https://mobaxterm.mobatek.net/), Windows 10 bash, or [PuTTY](https://www.putty.org/)
+   * MacOS X: Terminal app or iTerm2
+   * Linux: Terminal app or xterm
+ * A smartphone with Google Authenticator (recommended) or another app that implements the TOTP (Time-based One Time Password) algorithm installed
 
 ---
 
@@ -31,53 +32,50 @@ If you are logging in for the first time to Kupe, you will need to set up your a
 1. Access the [My NeSI Portal](https://my.nesi.org.nz) via your browser.
    ![logging-in](../../assets/img/portal_login.png)
 
-2. Log in using your institutional credentials via Tuakiri. If your institution is not a member of the Tuakiri federation, you will have to follow the 'Apply for a NeSI Account' link below th 'Log in' button to request a Tuakiri Virtual Home account. Once we have approved and created your Tuakiri Virtual Home account, please select the Tuakiri Virtual Home as your Home Organisation. See the example below, which shows the login process using a NIWA staff username and password. Otherwise, when logging in, please select your own home organisation.
+1. Log in using your institutional credentials via Tuakiri. If your institution is not a member of the Tuakiri federation, you will have to follow the 'Apply for a NeSI Account' link (at the bottom of your browser window, below the 'Log in' button) to request a Tuakiri Virtual Home account. Once we have approved and created your Tuakiri Virtual Home account, please select the Tuakiri Virtual Home as your Home Organisation. Otherwise, select your own employer or tertiary institution as your Home Organisation. See the example below, which shows the login process using a NIWA staff username and password. Your login screen will in most cases look different.
    ![logging-in](../../assets/img/tuakiri_credentials.png)
    ![logging-in](../../assets/img/niwa_turakiri.png)
 
-3. If this is the first time you have logged in to the [My NeSI Portal](https://my.nesi.org.nz) and you do not have an existing account with NeSI on Pan you will be prompted to request an account, after filling out some required fields. After submitting your request you must wait for our support team to contact you via email before continuing. If you have a Pan account, after logging in you will need to email [support@nesi.org.nz](mailto:support@nesi.org.nz?subject=Please%20confirm%20my%20My%20NeSI%20account%20and%20add%20me%20to%20a%20project%20team) and inform us that you are attempting to gain access to Kupe so that we can manually ensure that you have proper group membership needed to gain access.
-
+1. You will be asked to fill out some fields, such as your role at your institution and a contact telephone number.
    ![logging-in](../../assets/img/request_an_account.png)
-   
-4. After receiving confirmation from our support team to continue,log in to the [My NeSI Portal](https://my.nesi.org.nz) again. Once you have logged in, you should see a screen similar to the one below. Click on the 'Reset Password' button to proceed.
-wait for us to confirm your account and add you to an appropriate project group. This is currently a manual step that we aim to complete for every user within two business days of receiving the request.
+1. If this is the first time you have logged in to the [My NeSI Portal](https://my.nesi.org.nz):
 
-   If you don't see the 'Reset Password' button and instead see error messages, it means your information on our database does not match your Tuakiri identity, your user account has not yet been created, or you are not a member of an active project. In this case, please email [support@nesi.org.nz](mailto:support@nesi.org.nz?subject=Please%20confirm%20my%20My%20NeSI%20account%20and%20add%20me%20to%20a%20project%20team) and 
-
-   **NOTE:** You must wait at least an hour between password reset requests. If you request a password reset before an hour has gone by since your last valid password reset request, our system will ignore the later request.
+   * If you do not have an existing account with NeSI on Pan, please click the button to request an account on Kupe. After submitting your request, you must wait for our support team to contact you via email before continuing.
+   * If you have a Pan account, after logging in you will need to email [support@nesi.org.nz](mailto:support@nesi.org.nz?subject=Please%20confirm%20my%20My%20NeSI%20account%20and%20add%20me%20to%20a%20project%20team) and inform us that you would like access to Kupe so that we can add you to a group with Kupe access rights.
    
+1. Please wait for us to confirm your account and group membership. This is currently a manual step that we aim to complete for every user within two business days of receiving the request.
+
+1. After receiving confirmation from our support team, log in to the [My NeSI Portal](https://my.nesi.org.nz) again.
+
+1. Once you have logged in, you should see a screen similar to the one below. Click the 'Reset Password' button to proceed.
+
    ![logging-in](../../assets/img/login_success.png)
-   
-5. You will be sent an e-mail with a temporary URL. If you do not receive this email within a few minutes, check your spam filter.
 
-6. Clicking on the link on your e-mail will open up a web page looking like the following picture that contains your temporary password.
-   ![logging-in](../../assets/img/temp_password.png)
+   If you don't see the 'Reset Password' button, it means your information on our database does not match your Tuakiri identity, your user account has not yet been created, or you are not a member of an active project. In this case, please email [support@nesi.org.nz](mailto:support@nesi.org.nz?subject=Please%20confirm%20my%20My%20NeSI%20account%20and%20add%20me%20to%20a%20project%20team) and wait for a member of our support team to confirm your account and group membership.
+
+   **Note:** You must wait at least an hour between password reset requests. If you request a password reset before an hour has gone by since your last valid password reset request, our system will ignore the later request.
+   
+   
+1. You will be sent an e-mail from us with a temporary URL. If you do not receive this email within a few minutes, check your spam filter.
+
+1. Click on the link on your e-mail. The link will take you to a web page looking like the following picture and containing your unique temporary password.
 
    **WARNING:** Do **not** close the web page displaying your temporary password until you have completed the password reset process (see below). The temporary password link may only be opened once. If you accidentally close the page (or your browser or computer crashes), you will need to wait an hour before requesting a new password reset.
 
-   ![logging-in](../../assets/img/temp_password.png)
-
-### NeSI password policy
-
-The NeSI password policy is as follows:
-  * Your password must be at least 12 characters long
-  * Your password must contain one or more characters from at least two of the following classes:
-    * upper case letters
-    * lower case letters
-    * numbers
-    * allowed special characters
-   
----
-
-7. Resetting your password is a **six-step** process, detailed below. Once you have changed your password, your connection will eventually be terminated with `Permission denied (keyboard-interactive).` or `Access denied (keyboard-interactive).`. This is normal until you set up your second factor. Please ensure you read all six steps before proceeding as the output messages are easilly misleading.
+1. Logging in and resetting your password is a **six-step** process, detailed below. Once you have changed your password, your connection will eventually be terminated with `Permission denied (keyboard-interactive).` or `Access denied (keyboard-interactive).`. This is normal until you set up your second factor. Please ensure you read **all six steps** before proceeding as the output messages are easily misleading.
 
       You can choose your permanent password by following this **six-step** process:
-   1. For those using a Mac or Linux computer, connect to the lander node using the command:`ssh -Y <myusername>@lander.nesi.org.nz`, where `<myusername>` should be replaced with your Kupe login name, which you can find by logging in to [the My NeSI portal](https://my.nesi.org.nz) (not to be confused with your institutional login name). For those using a Windows computer, start a new session on MobaXterm and set the Remote Host to `lander.nesi.org.nz` and your username as your Kupe username. **Note:** When you first attempt to SSH into the lander node you may be met with a message warning you that the authenticity of the host cannot be established and asking if you wish to continue. You must type `yes` and press the `Enter` key. Typing `y` as a shorthand for "yes" is not sufficient.
+   1. Connect to the lander node:
+      * If you are using a Mac or Linux computer, connect to the lander node using the command:`ssh -Y <myusername>@lander.nesi.org.nz`, where `<myusername>` should be replaced with your Kupe login name, which you can find by logging in to [the My NeSI portal](https://my.nesi.org.nz) (not to be confused with your institutional login name). 
+      * If you are using a Windows computer, start a new session on MobaXterm and set the Remote Host to `lander.nesi.org.nz` and your username as your Kupe username.
+      
+      **Note:** When you first attempt to SSH into the lander node you may be met with a message warning you that the authenticity of the host cannot be established and asking if you wish to continue. You must type `yes` and press the `Enter` key. Typing `y` as a shorthand for "yes" is not sufficient.
+   
    2. When you first issue the SSH command to log in, you will be asked to enter a password. **You should enter your temporary password**.
-   3. Once you have correctly entered your temporary password, the system will report that the temporary password has expired and you will be asked to change it. First, the system will present a `Current Password:` prompt. **Enter your temporary password again.**
+   3. Once you have correctly entered your temporary password, you will be told that your temporary password has expired and asked to change it. First, the system will present a `Current Password:` prompt. **Enter your temporary password again.**
    4. Then, the system will ask you for **your NEW password** (`New password:`). Our system will only accept a password if it complies with [our password policy](#nesi-password-policy).
    5. You will be asked to **confirm your NEW password** (`Retype new password:`).
-   6. Once you have changed your password, either your session will be closed or you will be asked to enter a password again. **Do not try to enter your new password or your temporary password as neither will work.** Instead, press `Ctrl-C`, or press 'Enter' repeatedly until you get the `Access denied (keyboard-interactive).` (or `Permission denied (keyboard-interactive).`) message.
+   6. Once you have changed your password, either your session will be closed or you will be asked to enter a password again. **Do not try to enter your new password or your temporary password as neither will work.** Instead, press `Ctrl-C`, or press `Enter` repeatedly until you get the `Access denied (keyboard-interactive).` (or `Permission denied (keyboard-interactive).`) message.
    
    Example of the process:
    ```
@@ -105,30 +103,50 @@ The NeSI password policy is as follows:
 
    If you have to enter more than four passwords, something has probably gone wrong. You may have entered the wrong temporary password at one of the first two prompts, your new password may not satisfy our password criteria, or you may have mistyped your new password when confirming it. Alternatively, you may have accidentally pressed `Enter` or `Ctrl-C` at the wrong time. If any of these situations has happened, you should exit the session and log in again.
 
-8. You are now ready to move on to setting up two-factor authentication.
+1. You are now ready to move on to setting up two-factor authentication.
+
+---
+
+### NeSI password policy
+
+The NeSI password policy is as follows:
+  * Your password must be at least 12 characters long
+  * Your password must contain one or more characters from at least two of the following classes:
+    * upper case letters
+    * lower case letters
+    * numbers
+    * allowed special characters
+   
+---
 
 ## Setting up two-factor authentication
 
-Note: You can skip this section if you only ever log on to NeSI from inside the NIWA network or via NIWA's VPN.
+**Note:** You can skip this section if you only ever log on to NeSI from inside the NIWA network or via NIWA's VPN.
 
-Connecting to the HPC from outside the NIWA network requires two-factor authentication at all times. The first factor is your password, while the second factor is a single-use keycode provided by the Google Authenticator smartphone app. An alternative for NIWA staff members and other authorised persons is to use the NIWA VPN.
+Connecting to the HPC from outside the NIWA network requires two-factor authentication at all times. The first factor is your password, while the second factor is a single-use keycode generated by the TOTP algorithm. We recommend using the Google Authenticator smartphone app to obtain your single-use keycodes. An alternative for NIWA staff members and other authorised persons is to use the NIWA VPN.
 
-Before starting the two-factor authentication setup process, ensure that you have a smartphone with a working camera and install the free Google Authenticator app on your smartphone. The next step can only be done once. 
+Before starting the two-factor authentication setup process, ensure that you have a smartphone with a working camera and install the free Google Authenticator app (or another compatible app) on your smartphone. The next step can only be done once. 
 
 **WARNING:** The QR code shown in later steps is a one-time password and can not be regenerated or displayed again. If you do not capture the QR code, or if you lose the device storing the token, you will be unable to access your account. If this happens, please contact [support@nesi.org.nz](mailto:support@nesi.org.nz?subject=Please%20reset%20my%202FA%20token). After we validate your request, a member of the NeSI team will delete your authentication token so you can generate another for your account.
 
-Go back to [the My NeSI portal](https://my.nesi.org.nz) and click on Accounts or refresh the page. You should see a new option to 'Link your mobile device'
+1. Go back to [the My NeSI portal](https://my.nesi.org.nz) and click on Accounts (or, alternatively, refresh the page if it is still open). You should see a new option to 'Link your mobile device'.
 ![logging-in](../../assets/img/link_device.png)
 
-Clicking on 'Link your mobile device' will prepare your second factor token so that you can log in to our lander node from outside of the NIWA network. After clicking on 'Link your mobile device' you will be instructed to prepare your mobile device before proceeding.
+1. Click the 'Link your mobile device' button. This button will start the process to prepare your second factor token so that you can log in to our lander node from outside of the NIWA network. After clicking on 'Link your mobile device' you will be instructed to prepare your mobile device before proceeding.
 ![logging-in](../../assets/img/prepare_device.png)
 
-Click 'Continue' to display your QR code.
+1. Click 'Continue' to display your QR code.
 ![logging-in](../../assets/img/qr_code.png)
 
-Open your Google Authenticator app and click on the add button and select 'Scan a barcode'. Point your camera at the QR code displayed on the screen and it will be added to your phone.
+1. Open your Google Authenticator app (or other compatible app).
 
-Now logging in to the lander node will prompt you for 'First factor' where you enter your newly set password, and 'Second factor (optional)' which is the six-digit code displayed on your Google Authenticator app. The six-digit code rotates every 30 seconds, and it can only be used once even if it has not expired yet. This means that you can only login to the lander node once every 30 seconds. Also, even though the prompt says (optional), the Google Authenticator code is compulsory. We are working with the software developers to fix the message.
+1. If using Google Authenticator:
+   1. Click on the add button and select 'Scan a barcode'.
+   1. Point your camera at the QR code displayed on the screen. The NeSI token will be added to your phone.
+   
+   If using a different authentication app, follow the instructions that are relevant to that app.
+
+From now on, logging in to the lander node will prompt you for 'First factor' where you enter your previously set password, and 'Second factor (optional)' which is the six-digit code displayed on your Google Authenticator app. The six-digit code rotates every 30 seconds, and it can only be used once even if it has not expired yet. This means that you can only log in to the lander node once every 30 seconds. Also, even though the prompt says (optional), the second factor code is compulsory. We are working with the software developers to fix the message. For more information, please see [Connecting to kupe](#connecting-to-kupe).
 
 **Note:** You need to be an authorised member of an active project team to log in after you complete this step. If you believe you are an authorised project team member and and you are not able to log in using your credentials, please send us a message at [support@nesi.org.nz](mailto:support@nesi.org.nz?subject=Problems%20logging%20in). In your message, please tell us your Kupe user name, the project code for the NeSI project you think you belong to, and the name of the NeSI project owner.
 
@@ -182,7 +200,7 @@ using your Kupe account username and password (not your NIWA username and passwo
 
 ## Setting up access for connecting from outside of NIWA computer network (advanced)
 
-On most Linux and MacOS machines the login process can be simplified to just a single SSH command, jumping across the lander node on the way to kupe. With the following lines in your `~/.ssh/config` file you can run the command `ssh kupe` on your machine and it will take you straight to kupe. Since we are using an SSH ProxyCommand to jump first to the lander node, you will need to enter your 'First factor' (password) and then your 'Second factor' (from Google Authenticator) on the first jump and then a combination of your 'First factor'+'Second factor' on the second jump when prompted for a password. 
+On most Linux and Mac machines the login process can be simplified to just a single SSH command, jumping across the lander node on the way to kupe. With the following lines in your `~/.ssh/config` file you can run the command `ssh kupe` on your machine and it will take you straight to kupe. Since we are using an SSH ProxyCommand to jump first to the lander node, you will need to enter your 'First factor' (password) and then your 'Second factor' (from Google Authenticator) on the first jump and then a combination of your 'First factor'+'Second factor' on the second jump when prompted for a password. 
 ```
 Host kupe
    User your_username

--- a/_lessons/kupe/002-accessing_resources.md
+++ b/_lessons/kupe/002-accessing_resources.md
@@ -20,7 +20,7 @@ You will need a terminal program to log in to Kupe:
 - Windows: [MobaXterm](https://mobaxterm.mobatek.net/), Windows 10 bash, or [PuTTY](https://www.putty.org/)
 - MacOS X: Terminal app, iTerm2
 - Linux: Terminal app, xterm
-- A smartphone with the Google Authenticator app or another compatable authenticator app installed
+- A smartphone with the Google Authenticator app or another compatible authenticator app installed
 
 ---
 

--- a/_lessons/kupe/002-accessing_resources.md
+++ b/_lessons/kupe/002-accessing_resources.md
@@ -39,7 +39,10 @@ If you are logging in for the first time to Kupe, you will need to set up your a
 
    ![logging-in](../../assets/img/request_an_account.png)
    
-4. After receiving confirmation from our support team to continue,log in to the [My NeSI Portal](https://my.nesi.org.nz) again. Once you have logged in, you should see a screen similar to the one below. Click on the 'Reset Password' button to proceed.If you don't see the 'Reset Password' button and instead see error messages, it means your information on our database does not match your Tuakiri identity, your user account has not yet been created, or you are not a member of an active project. In this case, please email [support@nesi.org.nz](mailto:support@nesi.org.nz?subject=Please%20confirm%20my%20My%20NeSI%20account%20and%20add%20me%20to%20a%20project%20team) and wait for us to confirm your account and add you to an appropriate project group. This is currently a manual step that we aim to complete for every user within two business days of receiving the request.
+4. After receiving confirmation from our support team to continue,log in to the [My NeSI Portal](https://my.nesi.org.nz) again. Once you have logged in, you should see a screen similar to the one below. Click on the 'Reset Password' button to proceed.
+wait for us to confirm your account and add you to an appropriate project group. This is currently a manual step that we aim to complete for every user within two business days of receiving the request.
+
+If you don't see the 'Reset Password' button and instead see error messages, it means your information on our database does not match your Tuakiri identity, your user account has not yet been created, or you are not a member of an active project. In this case, please email [support@nesi.org.nz](mailto:support@nesi.org.nz?subject=Please%20confirm%20my%20My%20NeSI%20account%20and%20add%20me%20to%20a%20project%20team) and 
 
    **NOTE:** You must wait at least an hour between password reset requests. If you request a password reset before an hour has gone by since your last valid password reset request, our system will ignore the later request.
    


### PR DESCRIPTION
- Ensured it is clear that old Pan users will not get request account message, and how to proceed.
- Moved password email closure warning earlier.
- Reworded step 7.
- Added line break and reordered step 4.
- Moved password policy to before password reset.
- Made clear other authenticators are useable