### PR TITLE
 making it clear that .ssh/sockets needs to be created

### DIFF
--- a/_lessons/maui-and-mahuika/03-connecting.md
+++ b/_lessons/maui-and-mahuika/03-connecting.md
@@ -61,7 +61,11 @@ On most Linux, Windows and MacOS machines the login process can be simplified to
 If you use MobaXterm on Windows, activate the "Connect through SSH gateway (jump host)" section in the "Advanced SSH settings" tab and enter `lander02.nesi.org.nz` in the "Gateway SSH server" field, as well as your username in the "User" field.
 
 ### Linux and MacOS users
-Run `mkdir -p ~/.ssh/sockets` and add the following lines to `~/.ssh/config` on your machine (replacing `<myusername>` with your username),
+Run 
+```
+mkdir -p ~/.ssh/sockets
+```
+and add the following lines to `~/.ssh/config` on your machine (replacing `<myusername>` with your username),
 ```
 Host *
     ControlMaster auto


### PR DESCRIPTION
@chris I was helping a user yesterday getting multiplexing working and forgot to create the sockets file. This change is to make that step more obvious. 